### PR TITLE
updating a deprecated CBManager for CBCentralManager, that causes an…

### DIFF
--- a/OpenTrace/Bluetrace/BluetraceManager.swift
+++ b/OpenTrace/Bluetrace/BluetraceManager.swift
@@ -83,7 +83,7 @@ class BluetraceManager {
 
     func isBluetoothAuthorized() -> Bool {
         if #available(iOS 13.1, *) {
-            return CBManager.authorization == .allowedAlways
+            return CBCentralManager().authorization == .allowedAlways  
         } else {
             // todo: consider iOS 13.0, which has different behavior from 13.1 onwards
             return CBPeripheralManager.authorizationStatus() == .authorized


### PR DESCRIPTION
… error: Instance member 'authorization' cannot be used on type 'CBManager' on build