### PR TITLE
A few commented lines of code, which allow to login into the app and debug it without having Cloud Functions in place

### DIFF
--- a/OpenTrace/Bluetrace/BluetraceManager.swift
+++ b/OpenTrace/Bluetrace/BluetraceManager.swift
@@ -99,7 +99,7 @@ class BluetraceManager {
         case .unauthorized:
             presentBluetoothAlert("Unauth State")
         case .unknown:
-            presentBluetoothAlert("Unknown State")
+            ()
         case .unsupported:
             centralController.turnOn()
             presentBluetoothAlert("Unsupported State")

--- a/OpenTrace/Bluetrace/EncounterMessageManager.swift
+++ b/OpenTrace/Bluetrace/EncounterMessageManager.swift
@@ -53,6 +53,11 @@ class EncounterMessageManager {
     }
 
     func getTempId(onComplete: @escaping (String?) -> Void) {
+
+// Uncomment the code below to be able to debug bluetooth without getting tempIDs from firebase #bluetooth_debug
+//        let fakePayload = "Fj5jfbTtDySw8JoVsCmeul0wsoIcJKRPV0HtEFUlNvNg6C3wyGj8R1utPbw+Iz8tqAdpbxR1nSvr+ILXPG++"
+//        onComplete(fakePayload); return
+        
         // Check refreshDate
         if advtPayloadExpiry == nil ||  Date() > advtPayloadExpiry! {
             fetchBatchTempIdsFromFirebase { [unowned self](error: Error?, resp: (tempIds: [[String: Any]], refreshDate: Date)?) in

--- a/OpenTrace/Bluetrace/Protocol/v2/BluetraceV2.swift
+++ b/OpenTrace/Bluetrace/Protocol/v2/BluetraceV2.swift
@@ -25,6 +25,11 @@ class V2Peripheral: PeripheralProtocol {
     }
 
     func prepareReadRequestData(onComplete: @escaping (Data?) -> Void) {
+
+// Uncomment the code below to be able to debug bluetooth without getting tempIDs from firebase #bluetooth_debug
+//        let fakePayload: Data? = Data("Fj5jfbTtDySw8JoVsCmeul0wsoIcJKRPV0HtEFUlNvNg6C3wyGj8R1utPbw+Iz8tqAdpbxR1nSvr+ILXPG--".utf8)
+//        onComplete(fakePayload); return
+        
         if advtPayloadExpiry == nil ||  Date() > advtPayloadExpiry! {
             EncounterMessageManager.shared.fetchBatchTempIdsFromFirebase {(error: Error?, resp: (tempIds: [[String: Any]], refreshDate: Date)?) in
                 guard let response = resp else {

--- a/OpenTrace/Bluetrace/Structs/Encounter+EncounterRecord.swift
+++ b/OpenTrace/Bluetrace/Structs/Encounter+EncounterRecord.swift
@@ -8,6 +8,12 @@ import CoreData
 extension EncounterRecord {
 
     func saveToCoreData() {
+        
+        // Uncomment to be notified each time an encounter is saved (good for background mode debugging) #bluetooth_debug
+//        let content = UNMutableNotificationContent()
+//        content.body = self.description
+//        UNUserNotificationCenter.current().add(UNNotificationRequest(identifier: "debug", content: content, trigger: UNTimeIntervalNotificationTrigger(timeInterval: 1, repeats: false)))
+        
         DispatchQueue.main.async {
             guard let appDelegate =
                 UIApplication.shared.delegate as? AppDelegate else {

--- a/OpenTrace/Bluetrace/Structs/EncounterRecord.swift
+++ b/OpenTrace/Bluetrace/Structs/EncounterRecord.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 
-struct EncounterRecord: Encodable {
+struct EncounterRecord: Encodable, CustomStringConvertible {
     var timestamp: Date?
     var msg: String?
     var modelC: String?
@@ -13,6 +13,7 @@ struct EncounterRecord: Encodable {
     var txPower: Double?
     var org: String?
     var v: Int?
+    var description: String { return "\(self.timestamp?.description ?? "nil")\nid: \(self.msg ?? "nil")\no: \(self.org ?? "nil")\nrs: \(self.rssi ?? 0.0) \ntx: \(self.txPower ?? 0.0)\nlC:\(self.modelC ?? "nil")\nlP \(self.modelP ?? "nil")" }
 
     mutating func update(msg: String) {
         self.msg = msg

--- a/OpenTrace/Onboarding/View Controllers/OTPViewController.swift
+++ b/OpenTrace/Onboarding/View Controllers/OTPViewController.swift
@@ -152,6 +152,8 @@ class OTPViewController: UIViewController {
             }
 
             FirebaseAPIs.getHandshakePin { (pin) in
+                // Uncomment line below to debug without having firebase functions in place #bluetooth_debug
+                // result(.Success); return
                 if let pin = pin {
                     UserDefaults.standard.set(pin, forKey: OTPViewController.userDefaultsPinKey)
                     result(.Success)

--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ The "Share" message uses Firebase remote config. The key is "ShareText". If it i
 
 There is a debug screen accessible within the staging version of the app. This allows you to view the app's Bluetooth communication log. To access it, you first have to set up the app. Then, tap on the home screen image.
 
+Quick Setup without Cloud Functions (for debugging only): in order to exlore or debug only some of the functionality without the hassle of setting up Firebase Cloud Functions, there are stubs in the code, which you can uncomment. Search for `#bluetooth_debug` in code and uncomment respective lines. Note, that you still need a Firebase instance with "Phone" sign in method turned on in Authentication with some testing phone numbers added there.
+
 ## Linting
 
 There's a build script in `Targets > OpenTrace > Build Phases > Swiftlint` which runs [SwiftLint](https://github.com/realm/SwiftLint) on Build.


### PR DESCRIPTION
It will be helpful in case someone wants to mess with the Bluetooth part and doesn't need real tempIDs generation working. Ability to save time by skipping the Cloud Functions setup would make more people (like me) be able play with the code and find and fix issues.