### PR TITLE
Updating podfile's public source

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -1,7 +1,7 @@
 # Uncomment the next line to define a global platform for your project
 # platform :ios, '9.0'
 
-source 'https://github.com/CocoaPods/Specs.git'
+source 'https://cdn.cocoapods.org/'
 
 pod 'Firebase/Crashlytics'
 pod 'Firebase/Functions'


### PR DESCRIPTION
Using 'https://cdn.cocoapods.org/' instead of 'https://github.com/CocoaPods/Specs.git' to avoid cloning the whole spec repo separately.
cdn.cocoapods.org is the default cached pod spec repo thunk came together with installed Cocoapods.

Source: https://blog.cocoapods.org/CocoaPods-1.7.2/